### PR TITLE
fix: plants and thumbnails fail to load due to incorrect error check

### DIFF
--- a/src/plant.cpp
+++ b/src/plant.cpp
@@ -121,7 +121,9 @@ PlantResult Plants::openPlant(QString filePath)
 
    jsonData = jsonFile.readAll();
 
-   if (jsonData.isEmpty() || jsonFile.errorString() != "Unknown error")
+   // QFile::errorString() returns "Unknown error" when there is no error — do not use it as a
+   // failure indicator. Only check for empty data.
+   if (jsonData.isEmpty())
       return PlantResult{nullptr,
                          C::gettext("Failed to open plant JSON #2: ") + jsonFile.errorString()};
 
@@ -193,7 +195,9 @@ PlantResult Plants::_openPlant(QByteArray jsonData)
 
       imageData = thumbFile.readAll();
 
-      if (imageData.isEmpty() || thumbFile.errorString() != "Unknown error")
+      // QFile::errorString() returns "Unknown error" when there is no error — do not use it as a
+      // failure indicator. Only check for empty data.
+      if (imageData.isEmpty())
          return PlantResult{nullptr,
                             C::gettext("Failed to open plant image: ") + thumbFile.errorString()};
 


### PR DESCRIPTION
QFile::errorString() returns "Unknown error" as its default string when no error has occurred. The previous condition treated this default value as a read failure, causing every saved plant and its thumbnail to be rejected on reload.

Remove the errorString() check and rely solely on the empty-data guard, which is the correct indicator of a failed readAll().

It’s also a way of testing how responsive the maintainer is on this app, which I’m very interested in. I don’t want to create a duplicate on the Open Store if this one continues to be maintained. :)

Yes, I’m coding with Claude.